### PR TITLE
Improve replaying messages in salesforce inbound

### DIFF
--- a/src/main/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceConstant.java
+++ b/src/main/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceConstant.java
@@ -27,7 +27,6 @@ public class SalesforceConstant {
     public static final String SOAP_API_VERSION = "connection.salesforce.soapApiVersion";
     public static final String REPLAY_FROM = "connection.salesforce.replay";
     public static final String REPLAY_WITH_MULTIPLE_INBOUNDS = "connection.salesforce.replayWithMultipleInbounds";
-    public static final String INITIAL_EVENT_ID = "connection.salesforce.initialEventId";
     public static final String REPLAY_FROM_ID_Stored_File_Path = "connection.salesforce.EventIDStoredFilePath";
     public static final long REPLAY_FROM_EARLIEST = -2L;
     public static final long REPLAY_FROM_TIP = -1L;

--- a/src/main/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceConstant.java
+++ b/src/main/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceConstant.java
@@ -28,6 +28,7 @@ public class SalesforceConstant {
     public static final String REPLAY_FROM = "connection.salesforce.replay";
     public static final String REPLAY_WITH_MULTIPLE_INBOUNDS = "connection.salesforce.replayWithMultipleInbounds";
     public static final String REPLAY_FROM_ID_Stored_File_Path = "connection.salesforce.EventIDStoredFilePath";
+    public static final String INITIAL_EVENT_ID = "connection.salesforce.initialEventId";
     public static final long REPLAY_FROM_EARLIEST = -2L;
     public static final long REPLAY_FROM_TIP = -1L;
     public static final String RESOURCE_PATH = "connector/salesforce/event";

--- a/src/main/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceConstant.java
+++ b/src/main/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceConstant.java
@@ -26,10 +26,14 @@ public class SalesforceConstant {
     public static final String PACKAGE_VERSION = "connection.salesforce.packageVersion";
     public static final String SOAP_API_VERSION = "connection.salesforce.soapApiVersion";
     public static final String REPLAY_FROM = "connection.salesforce.replay";
+    public static final String REPLAY_WITH_MULTIPLE_INBOUNDS = "connection.salesforce.replayWithMultipleInbounds";
+    public static final String INITIAL_EVENT_ID = "connection.salesforce.initialEventId";
     public static final String REPLAY_FROM_ID_Stored_File_Path = "connection.salesforce.EventIDStoredFilePath";
     public static final long REPLAY_FROM_EARLIEST = -2L;
     public static final long REPLAY_FROM_TIP = -1L;
     public static final String RESOURCE_PATH = "connector/salesforce/event";
+    public static final String REGISTRY_PATH = "connector/salesforce";
+    public static final String SALESFORCE_EVENT = "event";
     public static final String PROPERTY_NAME = "eventID";
     //object for the salesforce inbound endpoint
     public static final String SOBJECT = "connection.salesforce.salesforceObject";

--- a/src/main/resources/uischema.json
+++ b/src/main/resources/uischema.json
@@ -220,6 +220,17 @@
           {
             "type": "attribute",
             "value": {
+              "name": "connection.salesforce.initialEventId",
+              "displayName": "InitialEventId",
+              "inputType": "string",
+              "defaultValue": "-1",
+              "required": "false",
+              "helpTip": "Initial event ID to start reading messages."
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
               "name": "connection.salesforce.replay",
               "displayName": "Replay",
               "inputType": "checkbox",

--- a/src/main/resources/uischema.json
+++ b/src/main/resources/uischema.json
@@ -238,6 +238,22 @@
               "helpTip": "Specify the file path of a text file to start replaying from the event ID stored in it.",
               "enableCondition": [{"connection.salesforce.replay":true}]
             }
+          },
+          {
+            "type": "attribute",
+            "value": {
+              "name": "connection.salesforce.replayWithMultipleInbounds",
+              "displayName": "Support replaying messages with multiple inbound endpoints",
+              "inputType": "checkbox",
+              "defaultValue": false,
+              "required": "false",
+              "helpTip": "When enabled, supports replaying messages with multiple inbound endpoints.",
+              "enableCondition": [
+                {
+                  "connection.salesforce.replay": true
+                }
+              ]
+            }
           }
         ]
       }


### PR DESCRIPTION
## Purpose
This PR has the following improvements for Replaying messages in salesforce inbound endpoint.
- connector/salesforce/event does not need to be created manually in the governance registry to store the event id.
- When a coordination issue is occurred in the cluster setup, events are processed from the last processed event.
- When `connection.salesforce.EventIDStoredFilePath` is configured, save the event Id to registry.
- To support multiple salesforce inbounds needs to add the following config. It will create event.properties file at the location connector/salesforce/{inbound-name}.
```
        <parameter name="connection.salesforce.replayWithMultipleInbounds">true</parameter>

 ```
- To add an initial event id to start message reading, following config can be added. This values will be used only if `connection.salesforce.EventIDStoredFilePath` is not configured and if this value is greater than the replayId stored in the registry.
```
        <parameter name="connection.salesforce.initialEventId">1234</parameter>

```

Fixes:https://github.com/wso2/product-micro-integrator/issues/4098
