### PR TITLE
Fix connection drop-off issue whenever received an unsuccessful message

### DIFF
--- a/src/main/java/org/wso2/carbon/inbound/salesforce/poll/EmpConnector.java
+++ b/src/main/java/org/wso2/carbon/inbound/salesforce/poll/EmpConnector.java
@@ -155,9 +155,6 @@ public class EmpConnector {
         if (client != null) {
             LOG.info("Forcefully shutting down Bayeux Client in EmpConnector");
 
-            // Unsubscribe from all active subscriptions
-            subscriptions.forEach(SubscriptionImpl::cancel);
-
             // Force disconnect
             client.abort();  // Immediately terminates transport connections
             boolean disconnected = client.waitFor(5000, BayeuxClient.State.DISCONNECTED);
@@ -171,7 +168,6 @@ public class EmpConnector {
         if (httpClient != null) {
             try {
                 LOG.info("Forcefully stopping HTTP client...");
-                httpClient.stop();   // Stop the HTTP client
                 httpClient.destroy(); // Destroy all resources
             } catch (Exception e) {
                 LOG.error("Error while shutting down HTTP transport[{}]", parameters.endpoint(), e);


### PR DESCRIPTION
## Purpose
> To resolve the connection drop-off issue after a particular time

## Goals
> We do not need to stop the HTTP client inorder to reconnect with Salesforce by stopping the CometD client lib is enough to re-establish the connection.

## Approach
> Removing the code segment related to terminating the HTTP client and the topic subscription canceling. The CometD client will re-authenticate with Salesforce and re-establish the connection and the session continues with a heartbeat message every 2 minutes(long-polling). Subscription to the topics needs to remain inorder to consume events after reconnect.
