### PR TITLE
Fix connection drop-off issue for both clustered and non-clustered deployments

### DIFF
--- a/src/main/java/org/wso2/carbon/inbound/salesforce/poll/EmpConnector.java
+++ b/src/main/java/org/wso2/carbon/inbound/salesforce/poll/EmpConnector.java
@@ -155,9 +155,6 @@ public class EmpConnector {
         if (client != null) {
             LOG.info("Forcefully shutting down Bayeux Client in EmpConnector");
 
-            // Unsubscribe from all active subscriptions
-            subscriptions.forEach(SubscriptionImpl::cancel);
-
             // Force disconnect
             client.abort();  // Immediately terminates transport connections
             boolean disconnected = client.waitFor(5000, BayeuxClient.State.DISCONNECTED);
@@ -171,7 +168,6 @@ public class EmpConnector {
         if (httpClient != null) {
             try {
                 LOG.info("Forcefully stopping HTTP client...");
-                httpClient.stop();   // Stop the HTTP client
                 httpClient.destroy(); // Destroy all resources
             } catch (Exception e) {
                 LOG.error("Error while shutting down HTTP transport[{}]", parameters.endpoint(), e);

--- a/src/main/java/org/wso2/carbon/inbound/salesforce/poll/EmpConnector.java
+++ b/src/main/java/org/wso2/carbon/inbound/salesforce/poll/EmpConnector.java
@@ -119,6 +119,7 @@ public class EmpConnector {
 
     // A reference to the ConnectionFailureListener to notify upon connection failure
     private ConnectionFailureListener failureListener;
+    private SalesforceStreamData salesforceStreamData;
 
     public EmpConnector(BayeuxParameters parameters, ConnectionFailureListener listener) {
         this.parameters = parameters;
@@ -126,6 +127,7 @@ public class EmpConnector {
         httpClient.getProxyConfiguration().getProxies().addAll(parameters.proxies());
         httpClient.setConnectTimeout(SalesforceDataHolderObject.connectionTimeout);
         failureListener = listener;
+        salesforceStreamData = (SalesforceStreamData) listener;
     }
 
     /**
@@ -152,9 +154,13 @@ public class EmpConnector {
         if (!running.compareAndSet(true, false)) {
             return;
         }
+        boolean coordinationEnabled = salesforceStreamData.isCoordinationEnabled();
         if (client != null) {
             LOG.info("Forcefully shutting down Bayeux Client in EmpConnector");
-
+            if (coordinationEnabled) {
+                // Unsubscribe from all active subscriptions
+                subscriptions.forEach(SubscriptionImpl::cancel);
+            }
             // Force disconnect
             client.abort();  // Immediately terminates transport connections
             boolean disconnected = client.waitFor(5000, BayeuxClient.State.DISCONNECTED);
@@ -168,6 +174,9 @@ public class EmpConnector {
         if (httpClient != null) {
             try {
                 LOG.info("Forcefully stopping HTTP client...");
+                if (coordinationEnabled) {
+                    httpClient.stop();   // Stop the HTTP client
+                }
                 httpClient.destroy(); // Destroy all resources
             } catch (Exception e) {
                 LOG.error("Error while shutting down HTTP transport[{}]", parameters.endpoint(), e);

--- a/src/main/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceStreamData.java
+++ b/src/main/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceStreamData.java
@@ -58,6 +58,7 @@ public class SalesforceStreamData extends GenericPollingConsumer implements Conn
     private int connectionTimeout;
     private int waitTime;
     private boolean isPolled = false;
+    private boolean isCoordinationEnabled = false;
     private SalesforceDataHolderObject SalesforceDataHolderObject=new SalesforceDataHolderObject();
     private EmpConnector connector;
     private AbstractRegistry registry;
@@ -359,6 +360,10 @@ public class SalesforceStreamData extends GenericPollingConsumer implements Conn
     @Override
     public void resume() {
         isPolled = false;
+    }
+
+    public boolean isCoordinationEnabled() {
+        return isCoordinationEnabled;
     }
 }
 


### PR DESCRIPTION
## Purpose
> To resolve the connection drop-off issue for both clustered and non-clustered deployments

## Goals
> When dealing with a non-clustered deployment, it is not necessary to stop the HTTP client to reconnect with Salesforce; simply stopping the CometD client library is sufficient to re-establish the connection. In the case of a clustered deployment, we have addressed connection drops by considering the coordination parameter.

## Approach
> In a non-clustered deployment, I removed the code segment that handled the termination of the HTTP client and the cancellation of topic subscriptions. The CometD client is designed to re-authenticate with Salesforce and re-establish the connection, allowing the session to continue with a heartbeat message sent every two minutes (using long-polling). It is important to maintain subscriptions to the topics to ensure that events can still be consumed after a reconnect. 
For clustered deployments, the scenario was addressed by conditionally checking the coordination parameter. 

With this fix, we only need to make sure that we disable coordination for the non-clustered deployment.