### PR TITLE
Enable coordination for both clustered and non-clustered deployments

### DIFF
--- a/src/main/java/org/wso2/carbon/inbound/salesforce/poll/EmpConnector.java
+++ b/src/main/java/org/wso2/carbon/inbound/salesforce/poll/EmpConnector.java
@@ -155,9 +155,6 @@ public class EmpConnector {
         if (client != null) {
             LOG.info("Forcefully shutting down Bayeux Client in EmpConnector");
 
-            // Unsubscribe from all active subscriptions
-            subscriptions.forEach(SubscriptionImpl::cancel);
-
             // Force disconnect
             client.abort();  // Immediately terminates transport connections
             boolean disconnected = client.waitFor(5000, BayeuxClient.State.DISCONNECTED);
@@ -171,7 +168,6 @@ public class EmpConnector {
         if (httpClient != null) {
             try {
                 LOG.info("Forcefully stopping HTTP client...");
-                httpClient.stop();   // Stop the HTTP client
                 httpClient.destroy(); // Destroy all resources
             } catch (Exception e) {
                 LOG.error("Error while shutting down HTTP transport[{}]", parameters.endpoint(), e);

--- a/src/main/java/org/wso2/carbon/inbound/salesforce/poll/EmpConnector.java
+++ b/src/main/java/org/wso2/carbon/inbound/salesforce/poll/EmpConnector.java
@@ -119,6 +119,7 @@ public class EmpConnector {
 
     // A reference to the ConnectionFailureListener to notify upon connection failure
     private ConnectionFailureListener failureListener;
+    private SalesforceStreamData salesforceStreamData;
 
     public EmpConnector(BayeuxParameters parameters, ConnectionFailureListener listener) {
         this.parameters = parameters;
@@ -126,6 +127,7 @@ public class EmpConnector {
         httpClient.getProxyConfiguration().getProxies().addAll(parameters.proxies());
         httpClient.setConnectTimeout(SalesforceDataHolderObject.connectionTimeout);
         failureListener = listener;
+        salesforceStreamData = (SalesforceStreamData) listener;
     }
 
     /**
@@ -152,9 +154,13 @@ public class EmpConnector {
         if (!running.compareAndSet(true, false)) {
             return;
         }
+        boolean coordinationEnabled = salesforceStreamData.isCoordinationEnabled();
         if (client != null) {
             LOG.info("Forcefully shutting down Bayeux Client in EmpConnector");
-
+            if (coordinationEnabled) {
+                // Unsubscribe from all active subscriptions
+                subscriptions.forEach(SubscriptionImpl::cancel);
+            }
             // Force disconnect
             client.abort();  // Immediately terminates transport connections
             boolean disconnected = client.waitFor(5000, BayeuxClient.State.DISCONNECTED);
@@ -168,6 +174,9 @@ public class EmpConnector {
         if (httpClient != null) {
             try {
                 LOG.info("Forcefully stopping HTTP client...");
+                if (coordinationEnabled) {
+                    httpClient.stop();   // Stop the HTTP client
+                }
                 httpClient.destroy(); // Destroy all resources
             } catch (Exception e) {
                 LOG.error("Error while shutting down HTTP transport[{}]", parameters.endpoint(), e);

--- a/src/main/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceStreamData.java
+++ b/src/main/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceStreamData.java
@@ -77,6 +77,7 @@ public class SalesforceStreamData extends GenericPollingConsumer implements Conn
         streamingEndpointUri = loginEndpoint;
         this.injectingSeq = injectingSeq;
         this.connectionFailed = false;
+        this.isCoordinationEnabled = coordination;
     }
 
     /**

--- a/src/main/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceStreamData.java
+++ b/src/main/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceStreamData.java
@@ -58,6 +58,7 @@ public class SalesforceStreamData extends GenericPollingConsumer implements Conn
     private int connectionTimeout;
     private int waitTime;
     private boolean isPolled = false;
+    private boolean isCoordinationEnabled = false;
     private SalesforceDataHolderObject SalesforceDataHolderObject=new SalesforceDataHolderObject();
     private EmpConnector connector;
     private AbstractRegistry registry;
@@ -359,6 +360,10 @@ public class SalesforceStreamData extends GenericPollingConsumer implements Conn
     @Override
     public void resume() {
         isPolled = false;
+    }
+
+    public boolean isCoordinationEnabled() {
+        return isCoordinationEnabled;
     }
 }
 


### PR DESCRIPTION
## Purpose
> Enable coordination for both clustered and non-clustered deployments

With this fix, we only need to ensure that coordination is used for clustered deployments and disabled for non-clustered deployments.