### PR TITLE
Fix  `httpClient.stop()` During Reconnection Attempts

### DIFF
--- a/.connector-store/meta.json
+++ b/.connector-store/meta.json
@@ -17,6 +17,18 @@
     ],
     "releases": [
         {
+            "tagName": "v2.1.12",
+            "products": [
+                "MI 4.4.0",
+                "MI 4.3.0",
+                "MI 4.2.0",
+                "MI 4.1.0"
+            ],
+            "operations": [],
+            "connections": [],
+            "isHidden": false
+        },
+        {
             "tagName": "v2.1.11",
             "products": [
                 "MI 4.4.0",

--- a/src/main/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceStreamData.java
+++ b/src/main/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceStreamData.java
@@ -58,7 +58,6 @@ public class SalesforceStreamData extends GenericPollingConsumer implements Conn
     private int connectionTimeout;
     private int waitTime;
     private boolean isPolled = false;
-    private boolean isCoordinationEnabled = false;
     private SalesforceDataHolderObject SalesforceDataHolderObject=new SalesforceDataHolderObject();
     private EmpConnector connector;
     private AbstractRegistry registry;
@@ -81,7 +80,6 @@ public class SalesforceStreamData extends GenericPollingConsumer implements Conn
         streamingEndpointUri = loginEndpoint;
         this.injectingSeq = injectingSeq;
         this.connectionFailed = false;
-        this.isCoordinationEnabled = coordination;
     }
 
     /**
@@ -218,6 +216,7 @@ public class SalesforceStreamData extends GenericPollingConsumer implements Conn
                 .addListener(Channel.META_UNSUBSCRIBE, loggingListener);
         connector.setBearerTokenProvider(tokenProvider);
         if (connector.isConnected()) {
+            LOG.info("Reinitializing the connector");
             connector.stop();
         }
         connector.start().get(waitTime, TimeUnit.MILLISECONDS);
@@ -401,7 +400,7 @@ public class SalesforceStreamData extends GenericPollingConsumer implements Conn
     @Override
     public void destroy() {
         if (connector != null) {
-            connector.stop();
+            connector.stop(true);
         }
     }
 
@@ -409,10 +408,6 @@ public class SalesforceStreamData extends GenericPollingConsumer implements Conn
     public void resume() {
         isPolled = false;
         isInitialEventIdUsed = false;
-    }
-
-    public boolean isCoordinationEnabled() {
-        return isCoordinationEnabled;
     }
 }
 

--- a/src/main/resources/uischema.json
+++ b/src/main/resources/uischema.json
@@ -111,9 +111,9 @@
               "name": "coordination",
               "displayName": "Coordination",
               "inputType": "checkbox",
-              "defaultValue": false,
+              "defaultValue": true,
               "required": "false",
-              "helpTip": "Only tick this if you are using clustered deployment. This will ensure that the inbound endpoint is only executed by one node in the cluster."
+              "helpTip": "This will ensure that the inbound endpoint is only executed by one node in the clustered environment."
             }
           }
         ]


### PR DESCRIPTION

### Summary

This PR addresses the issue of unnecessary shutdowns of the HTTP client during reconnection attempts in the `sf-inbound` connector. The logic has been updated to ensure that `httpClient.stop()` is invoked **only during shutdown**, and **not during reconnection attempts**. This change ensures the HTTP client and its thread pool remain active and reusable during disconnections, enabling seamless and reliable reconnections.

### Key Improvements

* `httpClient.stop()` is now triggered **only** during shutdown, **not** on reconnection.
* Ensures that the HTTP client and its thread pool remain **reusable** during disconnection scenarios.
* Prevents memory issues and maintains connector stability across different deployment setups.

### Testing

The updated implementation was tested across **all supported deployment environments** for over **190 minutes** each. In every case, the connector successfully reconnected after idle-induced session terminations, with no memory issues or unexpected errors.

#### ✅ Environments Tested:

* Coordinated Cluster
* Non-Coordinated Cluster
* Coordinated Non-Cluster
* Non-Coordinated Non-Cluster

### Detailed Results

#### **1. Non-Clustered (Coordinated Enabled)**

Performed 100 account creations, left idle to trigger session terminations.

* Duration: 190 minutes with memory analysis; 26 hours
* Terminations: 3 in memory analysis; 25
* Result: Reconnected successfully every time with no memory leaks.

  ![Image](https://github.com/user-attachments/assets/08c38878-6c13-48bf-845e-22bb5022449d)


#### **2. Non-Clustered (Coordinated Disabled)**

Same test applied with coordination disabled.

* Duration: 190 minutes
* Terminations: 3
* Result: Successful reconnections with no memory leaks.

![Image](https://github.com/user-attachments/assets/814addc7-62f5-4841-bfdf-caa74a668e59)

#### **3. Clustered (Non-Coordinated)**

Test repeated in a non-coordinated cluster setup.

* Duration: 190 minutes
* Terminations: 3
* Result: Connector reconnected as expected with no memory leaks.

**Node A:**
![Image](https://github.com/user-attachments/assets/6b932ff8-1b55-4c40-ab99-265b23dad886)

**Node B:**
![Image](https://github.com/user-attachments/assets/8399287c-cb29-4b04-b8da-1a8c6c87a15f)


#### **4. Clustered (Coordinated)**

Final test in a coordinated cluster environment.

* Duration: 200 minutes with memory analysis;
* Terminations: 3
* Result: All reconnections were successful, no memory issues observed

**Node A (sf-inbound-running):**
![Image](https://github.com/user-attachments/assets/aa4baa1d-1e19-4089-8ae1-6e0e01568e7c)

**Node B:**
![Image](https://github.com/user-attachments/assets/c0f99ae9-1aa8-463a-8329-569030469416)