### PR TITLE
Add fallback replay ID support and handle invalid replay ID exceptions

### DIFF
--- a/src/main/java/org/wso2/carbon/inbound/salesforce/poll/EmpConnector.java
+++ b/src/main/java/org/wso2/carbon/inbound/salesforce/poll/EmpConnector.java
@@ -96,11 +96,26 @@ public class EmpConnector {
                     if (error == null) {
                         error = message.get(FAILURE);
                     }
-                    future.completeExceptionally(new CannotSubscribe(parameters.endpoint(), topic, replayFrom,
-                            error != null ? error : message));
+                    String errorText = String.valueOf(error != null ? error : message);
+                    if (isInvalidReplayError(errorText))  {
+                        cancel();
+                        future.completeExceptionally(
+                                new InvalidReplayIdException(topic, replayFrom, errorText));
+                    } else {
+                        future.completeExceptionally(new CannotSubscribe(parameters.endpoint(), topic, replayFrom,
+                                error != null ? error : message));
+                    }
                 }
             });
             return future;
+        }
+
+        private boolean isInvalidReplayError(String errorText) {
+            if (errorText == null) {
+                return false;
+            }
+            String lower = errorText.toLowerCase();
+            return lower.contains("replayid") && lower.contains("invalid");
         }
     }
 

--- a/src/main/java/org/wso2/carbon/inbound/salesforce/poll/InvalidReplayIdException.java
+++ b/src/main/java/org/wso2/carbon/inbound/salesforce/poll/InvalidReplayIdException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.inbound.salesforce.poll;
+
+public class InvalidReplayIdException extends Exception {
+
+    private final long replayFrom;
+
+    public InvalidReplayIdException(String topic, long replayFrom, String errorText) {
+
+        super(String.format("Invalid replayId [%s] for topic [%s] : %s", replayFrom, topic, errorText));
+        this.replayFrom = replayFrom;
+    }
+
+    public long getReplayFrom() {
+
+        return replayFrom;
+    }
+}

--- a/src/main/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceConstant.java
+++ b/src/main/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceConstant.java
@@ -29,6 +29,7 @@ public class SalesforceConstant {
     public static final String REPLAY_WITH_MULTIPLE_INBOUNDS = "connection.salesforce.replayWithMultipleInbounds";
     public static final String REPLAY_FROM_ID_Stored_File_Path = "connection.salesforce.EventIDStoredFilePath";
     public static final String INITIAL_EVENT_ID = "connection.salesforce.initialEventId";
+    public static final String FALLBACK_REPLAY_ID = "connection.salesforce.fallbackReplayId";
     public static final long REPLAY_FROM_EARLIEST = -2L;
     public static final long REPLAY_FROM_TIP = -1L;
     public static final String RESOURCE_PATH = "connector/salesforce/event";

--- a/src/main/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceStreamData.java
+++ b/src/main/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceStreamData.java
@@ -67,6 +67,7 @@ public class SalesforceStreamData extends GenericPollingConsumer implements Conn
 
     // Flag indicating whether the connection has failed
     private boolean connectionFailed;
+    private long fallbackReplayId = Long.MIN_VALUE;
 
     public SalesforceStreamData(Properties salesforceProperties, String name, SynapseEnvironment synapseEnvironment,
                                 long scanInterval, String injectingSeq, String onErrorSeq, boolean coordination,
@@ -232,7 +233,26 @@ public class SalesforceStreamData extends GenericPollingConsumer implements Conn
                     .get(waitTime, TimeUnit.MILLISECONDS);
             LOG.info("Subscribed: " + subscription);
         } catch (ExecutionException e) {
-            LOG.error("Unable to subscribed for the event/topic", e);
+            Throwable cause = e.getCause();
+            // If the failure is due to an invalid replay ID and a fallback replay ID is configured,
+            // attempt to subscribe using the fallback replay ID
+            if (fallbackReplayId != Long.MIN_VALUE && cause instanceof InvalidReplayIdException) {
+                LOG.warn("Replay ID " + ((InvalidReplayIdException) cause).getReplayFrom() + " is invalid for topic " + salesforceObject
+                        + ". Retrying with fallback replay value: " + fallbackReplayId);
+                try {
+                    subscription = connector.subscribe(salesforceObject, fallbackReplayId, consumer)
+                            .get(waitTime, TimeUnit.MILLISECONDS);
+                    LOG.info("Subscribed with fallback replay: " + subscription);
+                } catch (ExecutionException retryEx) {
+                    LOG.error("Unable to subscribe after replay fallback", retryEx);
+                } catch (TimeoutException retryEx) {
+                    LOG.error("Timed out subscribing after replay fallback", retryEx);
+                } catch (InterruptedException retryEx) {
+                    LOG.error("Interrupted while subscribing after replay fallback", retryEx);
+                }
+            } else {
+                LOG.error("Unable to subscribed for the event/topic", e);
+            }
         } catch (TimeoutException e) {
             LOG.error("Timed out subscribing", e);
         } catch (InterruptedException e) {
@@ -328,6 +348,14 @@ public class SalesforceStreamData extends GenericPollingConsumer implements Conn
             } else {
                 //read id from  registry db
                 replayFromOption = getRegistryEventID();
+            }
+            if (properties.getProperty(SalesforceConstant.FALLBACK_REPLAY_ID) != null
+                    && StringUtils.isNotEmpty(properties.getProperty(SalesforceConstant.FALLBACK_REPLAY_ID))) {
+                try {
+                    fallbackReplayId = Long.parseLong(properties.getProperty(SalesforceConstant.FALLBACK_REPLAY_ID));
+                } catch (NumberFormatException e) {
+                    LOG.error("Fallback replay ID should be number", e);
+                }
             }
         } else {
             replayFromOption = SalesforceConstant.REPLAY_FROM_TIP;

--- a/src/main/resources/uischema.json
+++ b/src/main/resources/uischema.json
@@ -253,6 +253,17 @@
           {
             "type": "attribute",
             "value": {
+              "name": "connection.salesforce.fallbackReplayId",
+              "displayName": "Fallback Replay ID",
+              "inputType": "string",
+              "required": "false",
+              "helpTip": "Fallback event ID to start reading messages if the event ID stored in the Registry is invalid. -2 to replay all events, or -1 to replay only new events.",
+              "enableCondition": [{"connection.salesforce.replay": true}]
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
               "name": "connection.salesforce.replayWithMultipleInbounds",
               "displayName": "Support replaying messages with multiple inbound endpoints",
               "inputType": "checkbox",


### PR DESCRIPTION
fixes: https://github.com/wso2/product-micro-integrator/issues/4768
# Purpose
This pull request adds support for configuring a fallback replay ID when subscribing to Salesforce streaming events. If the initial replay ID is invalid, the connector will now attempt to subscribe using the fallback value, improving reliability and error handling. The changes introduce a new exception type, update the configuration schema, and enhance the subscription logic to handle invalid replay IDs more gracefully.