### PR TITLE
Add OAuth2 Client Credentials authentication support for Salesforce Streaming API

### DIFF
--- a/src/main/java/org/wso2/carbon/inbound/salesforce/poll/ClientCredentialsLoginHelper.java
+++ b/src/main/java/org/wso2/carbon/inbound/salesforce/poll/ClientCredentialsLoginHelper.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.inbound.salesforce.poll;
+
+import java.net.URL;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.util.FormContentProvider;
+import org.eclipse.jetty.util.Fields;
+import org.eclipse.jetty.util.ajax.JSON;
+
+/**
+ * Helper to obtain OAuth2 access token using Client Credentials grant type.
+ * Handles token exchange and provides BayeuxParameters with bearer token.
+ */
+public class ClientCredentialsLoginHelper {
+
+    private static final String GRANT_TYPE = "grant_type";
+    private static final String CLIENT_ID = "client_id";
+    private static final String CLIENT_SECRET = "client_secret";
+    private static final String ACCESS_TOKEN = "access_token";
+    private static final String INSTANCE_URL = "instance_url";
+
+    /**
+     * Obtain OAuth2 access token via Client Credentials grant and return BayeuxParameters
+     */
+    public static BayeuxParameters login(String clientId, String clientSecret, URL tokenEndpoint,
+                                         BayeuxParameters parameters) throws Exception {
+        HttpClient client = new HttpClient(parameters.sslContextFactory());
+        try {
+            client.getProxyConfiguration().getProxies().addAll(parameters.proxies());
+            client.setConnectTimeout(SalesforceDataHolderObject.connectionTimeout);
+            client.start();
+
+            Fields fields = new Fields();
+            fields.put(GRANT_TYPE, "client_credentials");
+            fields.put(CLIENT_ID, clientId);
+            fields.put(CLIENT_SECRET, clientSecret);
+
+            Request request = client.POST(tokenEndpoint.toURI());
+            request.content(new FormContentProvider(fields));
+            ContentResponse response = request.send();
+
+            if (response.getStatus() != 200) {
+                throw new RuntimeException("OAuth2 token exchange failed with status " + response.getStatus() +
+                        ": " + response.getContentAsString());
+            }
+
+            @SuppressWarnings("unchecked")
+            java.util.Map<String, Object> tokenResponse = (java.util.Map<String, Object>) JSON.parse(
+                    response.getContentAsString());
+
+            String accessToken = (String) tokenResponse.get(ACCESS_TOKEN);
+            String instanceUrl = (String) tokenResponse.get(INSTANCE_URL);
+
+            if (accessToken == null || instanceUrl == null) {
+                throw new RuntimeException("Missing access_token or instance_url in OAuth2 response");
+            }
+
+            URL instanceUrlObj = new URL(instanceUrl);
+            String cometdEndpoint = Float.parseFloat(parameters.version()) < 37 ? LoginHelper.COMETD_REPLAY_OLD : LoginHelper.COMETD_REPLAY;
+            URL replayEndpoint = new URL(instanceUrlObj.getProtocol(), instanceUrlObj.getHost(),
+                    instanceUrlObj.getPort(),
+                    cometdEndpoint + parameters.version());
+
+            return new DelegatingBayeuxParameters(parameters) {
+                @Override
+                public String bearerToken() {
+                    return accessToken;
+                }
+
+                @Override
+                public URL endpoint() {
+                    return replayEndpoint;
+                }
+            };
+        } finally {
+            client.stop();
+            client.destroy();
+        }
+    }
+}

--- a/src/main/java/org/wso2/carbon/inbound/salesforce/poll/ClientCredentialsLoginHelper.java
+++ b/src/main/java/org/wso2/carbon/inbound/salesforce/poll/ClientCredentialsLoginHelper.java
@@ -62,9 +62,17 @@ public class ClientCredentialsLoginHelper {
                         ": " + response.getContentAsString());
             }
 
+            Object parsedResponse;
+            try {
+                parsedResponse = JSON.parse(response.getContentAsString());
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to parse OAuth2 token response: " + response.getContentAsString(), e);
+            }
+            if (!(parsedResponse instanceof java.util.Map)) {
+                throw new RuntimeException("Unexpected OAuth2 token response format: " + parsedResponse);
+            }
             @SuppressWarnings("unchecked")
-            java.util.Map<String, Object> tokenResponse = (java.util.Map<String, Object>) JSON.parse(
-                    response.getContentAsString());
+            java.util.Map<String, Object> tokenResponse = (java.util.Map<String, Object>) parsedResponse;
 
             String accessToken = (String) tokenResponse.get(ACCESS_TOKEN);
             String instanceUrl = (String) tokenResponse.get(INSTANCE_URL);

--- a/src/main/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceConstant.java
+++ b/src/main/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceConstant.java
@@ -30,6 +30,15 @@ public class SalesforceConstant {
     public static final String REPLAY_FROM_ID_Stored_File_Path = "connection.salesforce.EventIDStoredFilePath";
     public static final String INITIAL_EVENT_ID = "connection.salesforce.initialEventId";
     public static final String FALLBACK_REPLAY_ID = "connection.salesforce.fallbackReplayId";
+    // Authentication type selection
+    public static final String AUTH_TYPE = "connection.salesforce.authenticationType";
+    public static final String AUTH_TYPE_SOAP = "username-token";
+    public static final String AUTH_TYPE_OAUTH = "oauth";
+    // oauth2 Client Credentials parameters
+    public static final String CLIENT_ID = "connection.salesforce.clientId";
+    public static final String CLIENT_SECRET = "connection.salesforce.clientSecret";
+    public static final String TOKEN_ENDPOINT = "connection.salesforce.tokenEndpoint";
+    public static final String DEFAULT_TOKEN_ENDPOINT = "https://login.salesforce.com/services/oauth2/token";
     public static final long REPLAY_FROM_EARLIEST = -2L;
     public static final long REPLAY_FROM_TIP = -1L;
     public static final String RESOURCE_PATH = "connector/salesforce/event";

--- a/src/main/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceStreamData.java
+++ b/src/main/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceStreamData.java
@@ -215,12 +215,12 @@ public class SalesforceStreamData extends GenericPollingConsumer implements Conn
             BayeuxParameters initialParams = new BayeuxParameters() {
                 @Override
                 public String bearerToken() {
-                    return null;
+                    throw new IllegalStateException("Bearer token is not available before OAuth2 token exchange");
                 }
 
                 @Override
                 public URL endpoint() {
-                    return null;
+                    throw new IllegalStateException("Endpoint is not available before OAuth2 token exchange");
                 }
             };
             tokenProvider = new BearerTokenProvider(() -> {
@@ -326,7 +326,11 @@ public class SalesforceStreamData extends GenericPollingConsumer implements Conn
         // Load authentication type
         String authTypeParam = properties.getProperty(SalesforceConstant.AUTH_TYPE);
         if (authTypeParam != null && !StringUtils.isEmpty(authTypeParam)) {
-            authType = authTypeParam;
+            authType = authTypeParam.trim().toLowerCase();
+            if (!SalesforceConstant.AUTH_TYPE_SOAP.equals(authType) && !SalesforceConstant.AUTH_TYPE_OAUTH.equals(authType)) {
+                handleException("Invalid authenticationType '" + authType + "'. Supported values: "
+                        + SalesforceConstant.AUTH_TYPE_SOAP + ", " + SalesforceConstant.AUTH_TYPE_OAUTH);
+            }
         }
         if (SalesforceConstant.AUTH_TYPE_OAUTH.equals(authType)) {
             clientId = properties.getProperty(SalesforceConstant.CLIENT_ID);

--- a/src/main/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceStreamData.java
+++ b/src/main/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceStreamData.java
@@ -69,6 +69,12 @@ public class SalesforceStreamData extends GenericPollingConsumer implements Conn
     private boolean connectionFailed;
     private long fallbackReplayId = Long.MIN_VALUE;
 
+    // Authentication type and oauth2 parameters
+    private String authType = SalesforceConstant.AUTH_TYPE_SOAP;
+    private String clientId;
+    private String clientSecret;
+    private String tokenEndpoint;
+
     public SalesforceStreamData(Properties salesforceProperties, String name, SynapseEnvironment synapseEnvironment,
                                 long scanInterval, String injectingSeq, String onErrorSeq, boolean coordination,
                                 boolean sequential) {
@@ -202,13 +208,40 @@ public class SalesforceStreamData extends GenericPollingConsumer implements Conn
                 (Long) ((HashMap) event.
                         get(SalesforceConstant.EVENT)).get(SalesforceConstant.REPLAY_ID));
         BearerTokenProvider tokenProvider;
-        tokenProvider = new BearerTokenProvider(() -> {
-            try {
-                return LoginHelper.login(new URL(streamingEndpointUri), userName, password);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
+
+        if (SalesforceConstant.AUTH_TYPE_OAUTH.equals(authType)) {
+            // oauth2 Client Credentials flow — initialParams provides default SSL/proxy config;
+            // bearerToken() and endpoint() are supplied by ClientCredentialsLoginHelper after token exchange.
+            BayeuxParameters initialParams = new BayeuxParameters() {
+                @Override
+                public String bearerToken() {
+                    return null;
+                }
+
+                @Override
+                public URL endpoint() {
+                    return null;
+                }
+            };
+            tokenProvider = new BearerTokenProvider(() -> {
+                try {
+                    return ClientCredentialsLoginHelper.login(clientId, clientSecret, new URL(tokenEndpoint),
+                            initialParams);
+                } catch (Exception e) {
+                    LOG.error("oauth2 token exchange failed", e);
+                    throw new RuntimeException("Failed to obtain oauth2 token: " + e.getMessage(), e);
+                }
+            });
+        } else {
+            // Username/Password (SOAP) authentication
+            tokenProvider = new BearerTokenProvider(() -> {
+                try {
+                    return LoginHelper.login(new URL(streamingEndpointUri), userName, password);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
         BayeuxParameters params = tokenProvider.login();
         connector = new EmpConnector(params, this);
         LoggingListener loggingListener = new LoggingListener(true, true);
@@ -290,6 +323,30 @@ public class SalesforceStreamData extends GenericPollingConsumer implements Conn
         if (LOG.isDebugEnabled()) {
             LOG.debug("Starting to load the salesforce credentials");
         }
+        // Load authentication type
+        String authTypeParam = properties.getProperty(SalesforceConstant.AUTH_TYPE);
+        if (authTypeParam != null && !StringUtils.isEmpty(authTypeParam)) {
+            authType = authTypeParam;
+        }
+        if (SalesforceConstant.AUTH_TYPE_OAUTH.equals(authType)) {
+            clientId = properties.getProperty(SalesforceConstant.CLIENT_ID);
+            clientSecret = properties.getProperty(SalesforceConstant.CLIENT_SECRET);
+            if (StringUtils.isEmpty(clientId) || StringUtils.isEmpty(clientSecret)) {
+                handleException("oauth authentication requires both clientId and clientSecret");
+            }
+            tokenEndpoint = properties.getProperty(SalesforceConstant.TOKEN_ENDPOINT);
+            if (StringUtils.isEmpty(tokenEndpoint)) {
+                tokenEndpoint = SalesforceConstant.DEFAULT_TOKEN_ENDPOINT;
+            }
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("oauth authentication enabled for Salesforce");
+            }
+        } else {
+            if (StringUtils.isEmpty(userName) || StringUtils.isEmpty(password)) {
+                handleException("username-token authentication requires both userName and password");
+            }
+        }
+
         if (properties.getProperty(SalesforceConstant.CONNECTION_TIMEOUT) == null) {
             connectionTimeout = SalesforceConstant.CONNECTION_TIMEOUT_DEFAULT;
         } else {

--- a/src/main/resources/uischema.json
+++ b/src/main/resources/uischema.json
@@ -131,7 +131,7 @@
               "displayName": "Salesforce Object",
               "inputType": "string",
               "required": "true",
-              "helpTip": "Name of the Salesforce object to interact with."
+              "helpTip": "The Push Topic or Platform Event channel to subscribe to (e.g. /topic/Account or /data/AccountChangeEvent)."
             }
           },
           {
@@ -141,7 +141,19 @@
               "displayName": "Package Version",
               "inputType": "string",
               "required": "true",
-              "helpTip": "Version of the Salesforce package."
+              "helpTip": "Salesforce Streaming API version (e.g. 37.0)."
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
+              "name": "connection.salesforce.authenticationType",
+              "displayName": "Authentication Type",
+              "inputType": "combo",
+              "comboValues": ["username-token", "oauth"],
+              "defaultValue": "username-token",
+              "required": "true",
+              "helpTip": "Select 'username-token' for SOAP login. Select 'oauth' to use oauth2 Client Credentials (no user context required)."
             }
           },
           {
@@ -151,7 +163,8 @@
               "displayName": "User Name",
               "inputType": "string",
               "required": "true",
-              "helpTip": "Salesforce login user name."
+              "helpTip": "Salesforce login username.",
+              "enableCondition": [{"connection.salesforce.authenticationType": "username-token"}]
             }
           },
           {
@@ -161,7 +174,8 @@
               "displayName": "Password",
               "inputType": "string",
               "required": "true",
-              "helpTip": "Salesforce login password."
+              "helpTip": "Salesforce login password concatenated with the security token (e.g. myPasswordXXXXXXXX).",
+              "enableCondition": [{"connection.salesforce.authenticationType": "username-token"}]
             }
           },
           {
@@ -172,7 +186,42 @@
               "inputType": "string",
               "defaultValue": "https://login.salesforce.com",
               "required": "true",
-              "helpTip": "Salesforce login URL endpoint."
+              "helpTip": "Salesforce SOAP login endpoint. Use https://test.salesforce.com for sandboxes.",
+              "enableCondition": [{"connection.salesforce.authenticationType": "username-token"}]
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
+              "name": "connection.salesforce.clientId",
+              "displayName": "Client ID",
+              "inputType": "string",
+              "required": "true",
+              "helpTip": "oauth2 consumer key from the Salesforce Connected App.",
+              "enableCondition": [{"connection.salesforce.authenticationType": "oauth"}]
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
+              "name": "connection.salesforce.clientSecret",
+              "displayName": "Client Secret",
+              "inputType": "string",
+              "required": "true",
+              "helpTip": "oauth2 consumer secret from the Salesforce Connected App.",
+              "enableCondition": [{"connection.salesforce.authenticationType": "oauth"}]
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
+              "name": "connection.salesforce.tokenEndpoint",
+              "displayName": "Token Endpoint",
+              "inputType": "string",
+              "defaultValue": "https://login.salesforce.com/services/oauth2/token",
+              "required": "true",
+              "helpTip": "oauth2 token endpoint. Use https://test.salesforce.com/services/oauth2/token for sandboxes.",
+              "enableCondition": [{"connection.salesforce.authenticationType": "oauth"}]
             }
           }
         ]

--- a/src/main/resources/uischema.json
+++ b/src/main/resources/uischema.json
@@ -128,7 +128,7 @@
             "type": "attribute",
             "value": {
               "name": "connection.salesforce.salesforceObject",
-              "displayName": "Salesforce Object",
+              "displayName": "Channel",
               "inputType": "string",
               "required": "true",
               "helpTip": "The Push Topic or Platform Event channel to subscribe to (e.g. /topic/Account or /data/AccountChangeEvent)."
@@ -138,7 +138,7 @@
             "type": "attribute",
             "value": {
               "name": "connection.salesforce.packageVersion",
-              "displayName": "Package Version",
+              "displayName": "Streaming API Version",
               "inputType": "string",
               "required": "true",
               "helpTip": "Salesforce Streaming API version (e.g. 37.0)."
@@ -153,7 +153,7 @@
               "comboValues": ["username-token", "oauth"],
               "defaultValue": "username-token",
               "required": "true",
-              "helpTip": "Select 'username-token' for SOAP login. Select 'oauth' to use oauth2 Client Credentials (no user context required)."
+              "helpTip": "Select 'username-token' for SOAP login. Select 'oauth' to use OAuth2 Client Credentials (no user context required)."
             }
           },
           {
@@ -197,7 +197,7 @@
               "displayName": "Client ID",
               "inputType": "string",
               "required": "true",
-              "helpTip": "oauth2 consumer key from the Salesforce Connected App.",
+              "helpTip": "OAuth2 consumer key from the Salesforce Connected App.",
               "enableCondition": [{"connection.salesforce.authenticationType": "oauth"}]
             }
           },
@@ -208,7 +208,7 @@
               "displayName": "Client Secret",
               "inputType": "string",
               "required": "true",
-              "helpTip": "oauth2 consumer secret from the Salesforce Connected App.",
+              "helpTip": "OAuth2 consumer secret from the Salesforce Connected App.",
               "enableCondition": [{"connection.salesforce.authenticationType": "oauth"}]
             }
           },
@@ -220,7 +220,7 @@
               "inputType": "string",
               "defaultValue": "https://login.salesforce.com/services/oauth2/token",
               "required": "true",
-              "helpTip": "oauth2 token endpoint. Use https://test.salesforce.com/services/oauth2/token for sandboxes.",
+              "helpTip": "OAuth2 token endpoint. Use https://test.salesforce.com/services/oauth2/token for sandboxes.",
               "enableCondition": [{"connection.salesforce.authenticationType": "oauth"}]
             }
           }

--- a/src/main/resources/uischema.json
+++ b/src/main/resources/uischema.json
@@ -128,17 +128,17 @@
             "type": "attribute",
             "value": {
               "name": "connection.salesforce.salesforceObject",
-              "displayName": "Channel",
+              "displayName": "Salesforce Object",
               "inputType": "string",
               "required": "true",
-              "helpTip": "The Push Topic or Platform Event channel to subscribe to (e.g. /topic/Account or /data/AccountChangeEvent)."
+              "helpTip": "Name of the Salesforce object to interact with."
             }
           },
           {
             "type": "attribute",
             "value": {
               "name": "connection.salesforce.packageVersion",
-              "displayName": "Streaming API Version",
+              "displayName": "Salesforce API Version",
               "inputType": "string",
               "required": "true",
               "helpTip": "Salesforce Streaming API version (e.g. 37.0)."

--- a/src/test/java/org/wso2/carbon/inbound/salesforce/poll/BearerTokenProviderTest.java
+++ b/src/test/java/org/wso2/carbon/inbound/salesforce/poll/BearerTokenProviderTest.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.inbound.salesforce.poll;
 
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.modules.testng.PowerMockTestCase;
@@ -33,6 +34,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
 
+@PowerMockIgnore({"javax.net.ssl.*", "jdk.internal.*"})
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({BearerTokenProvider.class, SalesforceStreamData.class})
 public class BearerTokenProviderTest extends PowerMockTestCase {

--- a/src/test/java/org/wso2/carbon/inbound/salesforce/poll/LogginListnerTest.java
+++ b/src/test/java/org/wso2/carbon/inbound/salesforce/poll/LogginListnerTest.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.inbound.salesforce.poll;
 
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.IObjectFactory;
@@ -29,6 +30,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import org.cometd.bayeux.Message;
 import org.cometd.bayeux.client.ClientSessionChannel;
 
+@PowerMockIgnore({"javax.net.ssl.*", "jdk.internal.*"})
 @RunWith(PowerMockRunner.class)
 public class LogginListnerTest extends PowerMockTestCase {
     private LoggingListener loggingListener;

--- a/src/test/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceStreamDataTest.java
+++ b/src/test/java/org/wso2/carbon/inbound/salesforce/poll/SalesforceStreamDataTest.java
@@ -21,6 +21,10 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.log4j.BasicConfigurator;
+import org.apache.synapse.SynapseException;
+import org.apache.synapse.config.SynapseConfiguration;
+import org.apache.synapse.core.SynapseEnvironment;
+import org.apache.synapse.registry.AbstractRegistry;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -35,17 +39,16 @@ import org.testng.IObjectFactory;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
-import java.io.InputStream;
-import static org.mockito.MockitoAnnotations.initMocks;
-import static org.powermock.api.mockito.PowerMockito.spy;
-import java.util.Properties;
-import org.apache.synapse.core.SynapseEnvironment;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
-import org.apache.synapse.config.SynapseConfiguration;
-import org.apache.synapse.core.axis2.Axis2SynapseEnvironment;
 
-@PowerMockIgnore({"javax.net.ssl.*"})
+import java.io.InputStream;
+import java.util.Properties;
+
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.powermock.api.mockito.PowerMockito.spy;
+
+@PowerMockIgnore({"javax.net.ssl.*", "jdk.internal.*"})
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({StringUtils.class, PrivilegedCarbonContext.class, CarbonContext.class})
 @SuppressStaticInitializationFor
@@ -71,15 +74,7 @@ public class SalesforceStreamDataTest extends PowerMockTestCase {
 
     @Test(description = "read id from given file and subscribed to platform event")
     public void testFile() throws Exception {
-
-        System.setProperty("carbon.home", ".");
-
-        PowerMockito.mockStatic(PrivilegedCarbonContext.class);
-        PowerMockito.mockStatic(CarbonContext.class);
-        SynapseConfiguration config = new SynapseConfiguration();
-        this.synapseEnvironment = new Axis2SynapseEnvironment(config);
-        PrivilegedCarbonContext privilegedCarbonContext = Mockito.mock(PrivilegedCarbonContext.class);
-
+        setupMocks();
         Properties properties = new Properties();
         properties.setProperty("inbound.behavior", "polling");
         properties.setProperty("interval", "1000");
@@ -91,26 +86,28 @@ public class SalesforceStreamDataTest extends PowerMockTestCase {
         properties.setProperty("connection.salesforce.connectionTimeout", "20000");
         properties.setProperty("connection.salesforce.soapApiVersion", "22.0");
         loadPropertiesFromFile(properties);
-        properties.setProperty("connection.salesforce.replay","true");
+        // Fall back to dummy values when Property.properties is empty (e.g. CI).
+        // Fill Property.properties with real credentials to test against a live org.
+        if (StringUtils.isEmpty(properties.getProperty("connection.salesforce.userName"))) {
+            properties.setProperty("connection.salesforce.userName", "testUser");
+        }
+        if (StringUtils.isEmpty(properties.getProperty("connection.salesforce.password"))) {
+            properties.setProperty("connection.salesforce.password", "testPass");
+        }
+        if (StringUtils.isEmpty(properties.getProperty("connection.salesforce.salesforceObject"))) {
+            properties.setProperty("connection.salesforce.salesforceObject", "/topic/TestTopic");
+        }
+        properties.setProperty("connection.salesforce.replay", "true");
 
-        PowerMockito.when(PrivilegedCarbonContext.getThreadLocalCarbonContext()).thenReturn(privilegedCarbonContext);
         salesforceStreamData = spy(new SalesforceStreamData(properties, "SaleforceInboundEP", synapseEnvironment, 100, "test", "fault", true, true));
-
         PowerMockito.whenNew(LoginHelper.class).withAnyArguments().thenReturn(loginHelper);
         Assert.assertNull(salesforceStreamData.poll());
         salesforceStreamData.destroy();
     }
 
-    @Test(description = "Subscribed to platform event and recieve from current event")
+    @Test(description = "Subscribed to platform event and receive from current event")
     public void testreplayOff() throws Exception {
-
-        System.setProperty("carbon.home", ".");
-        PowerMockito.mockStatic(PrivilegedCarbonContext.class);
-        PowerMockito.mockStatic(CarbonContext.class);
-        SynapseConfiguration config = new SynapseConfiguration();
-        this.synapseEnvironment = new Axis2SynapseEnvironment(config);
-        PrivilegedCarbonContext privilegedCarbonContext = Mockito.mock(PrivilegedCarbonContext.class);
-
+        setupMocks();
         Properties properties = new Properties();
         properties.setProperty("inbound.behavior", "polling");
         properties.setProperty("interval", "1000");
@@ -121,16 +118,199 @@ public class SalesforceStreamDataTest extends PowerMockTestCase {
         properties.setProperty("connection.salesforce.connectionTimeout", "20000");
         properties.setProperty("connection.salesforce.soapApiVersion", "22.0");
         loadPropertiesFromFile(properties);
-        properties.setProperty("connection.salesforce.replay","false");
+        // Fall back to dummy values when Property.properties is empty (e.g. CI).
+        // Fill Property.properties with real credentials to test against a live org.
+        if (StringUtils.isEmpty(properties.getProperty("connection.salesforce.userName"))) {
+            properties.setProperty("connection.salesforce.userName", "testUser");
+        }
+        if (StringUtils.isEmpty(properties.getProperty("connection.salesforce.password"))) {
+            properties.setProperty("connection.salesforce.password", "testPass");
+        }
+        if (StringUtils.isEmpty(properties.getProperty("connection.salesforce.salesforceObject"))) {
+            properties.setProperty("connection.salesforce.salesforceObject", "/topic/TestTopic");
+        }
+        properties.setProperty("connection.salesforce.replay", "false");
 
-        PowerMockito.when(PrivilegedCarbonContext.getThreadLocalCarbonContext()).thenReturn(privilegedCarbonContext);
         salesforceStreamData = spy(new SalesforceStreamData(properties, "SaleforceInboundEP", synapseEnvironment, 100, "test", "fault", true, true));
         PowerMockito.whenNew(LoginHelper.class).withAnyArguments().thenReturn(loginHelper);
         Assert.assertNull(salesforceStreamData.poll());
     }
 
-    public void loadPropertiesFromFile(Properties prop) {
+    @Test(description = "OAuth2 client credentials flow - poll() completes without throwing. "
+            + "With real credentials in Property.properties, this exercises a live token exchange and channel subscription.")
+    public void testOAuthClientCredentials() throws Exception {
+        setupMocks();
+        Properties properties = new Properties();
+        properties.setProperty("inbound.behavior", "polling");
+        properties.setProperty("interval", "1000");
+        properties.setProperty("sequential", "true");
+        properties.setProperty("coordination", "true");
+        properties.setProperty("connection.salesforce.packageVersion", "37.0");
+        properties.setProperty("connection.salesforce.waitTime", "5000");
+        properties.setProperty("connection.salesforce.connectionTimeout", "20000");
+        properties.setProperty("connection.salesforce.soapApiVersion", "22.0");
+        properties.setProperty("connection.salesforce.authenticationType", "oauth");
+        loadPropertiesFromFile(properties);
+        // Fall back to dummy values when Property.properties is empty (e.g. CI).
+        // Fill Property.properties with real OAuth credentials to test against a live org.
+        if (StringUtils.isEmpty(properties.getProperty("connection.salesforce.clientId"))) {
+            properties.setProperty("connection.salesforce.clientId", "dummyClientId");
+        }
+        if (StringUtils.isEmpty(properties.getProperty("connection.salesforce.clientSecret"))) {
+            properties.setProperty("connection.salesforce.clientSecret", "dummyClientSecret");
+        }
+        if (StringUtils.isEmpty(properties.getProperty("connection.salesforce.salesforceObject"))) {
+            properties.setProperty("connection.salesforce.salesforceObject", "/topic/TestTopic");
+        }
+        // Use a non-routable endpoint in CI so the test fails fast without making external network calls.
+        if (StringUtils.isEmpty(properties.getProperty("connection.salesforce.tokenEndpoint"))) {
+            properties.setProperty("connection.salesforce.tokenEndpoint", "http://localhost:0/token");
+        }
 
+        salesforceStreamData = spy(new SalesforceStreamData(properties, "OAuthInboundEP", synapseEnvironment, 100, "test", "fault", true, true));
+        // poll() always returns null by design — it is a listener-based inbound; events are pushed via the consumer callback.
+        Assert.assertNull(salesforceStreamData.poll());
+    }
+
+    // -------------------------------------------------------------------------
+    // Authentication type validation tests
+    // -------------------------------------------------------------------------
+
+    @Test(description = "No authenticationType set defaults to username-token with valid credentials")
+    public void testDefaultAuthTypeUsernameToken() throws Exception {
+        setupMocks();
+        Properties properties = buildBaseProperties();
+        properties.setProperty("connection.salesforce.userName", "testUser");
+        properties.setProperty("connection.salesforce.password", "testPass");
+
+        Assert.assertNotNull(buildStreamData(properties));
+    }
+
+    @Test(description = "Explicit username-token authenticationType with valid credentials succeeds")
+    public void testExplicitUsernameTokenAuthType() throws Exception {
+        setupMocks();
+        Properties properties = buildBaseProperties();
+        properties.setProperty("connection.salesforce.authenticationType", "username-token");
+        properties.setProperty("connection.salesforce.userName", "testUser");
+        properties.setProperty("connection.salesforce.password", "testPass");
+
+        Assert.assertNotNull(buildStreamData(properties));
+    }
+
+    @Test(description = "oauth authenticationType with valid clientId and clientSecret succeeds")
+    public void testOauthAuthTypeWithValidCredentials() throws Exception {
+        setupMocks();
+        Properties properties = buildBaseProperties();
+        properties.setProperty("connection.salesforce.authenticationType", "oauth");
+        properties.setProperty("connection.salesforce.clientId", "testClientId");
+        properties.setProperty("connection.salesforce.clientSecret", "testClientSecret");
+
+        Assert.assertNotNull(buildStreamData(properties));
+    }
+
+    @Test(description = "Auth type value is trimmed and lowercased before validation")
+    public void testAuthTypeNormalization() throws Exception {
+        setupMocks();
+        Properties properties = buildBaseProperties();
+        properties.setProperty("connection.salesforce.authenticationType", "  OAuth  ");
+        properties.setProperty("connection.salesforce.clientId", "testClientId");
+        properties.setProperty("connection.salesforce.clientSecret", "testClientSecret");
+
+        Assert.assertNotNull(buildStreamData(properties));
+    }
+
+    @Test(expectedExceptions = SynapseException.class,
+            description = "Unknown authenticationType throws SynapseException immediately")
+    public void testInvalidAuthTypeThrowsException() throws Exception {
+        setupMocks();
+        Properties properties = buildBaseProperties();
+        properties.setProperty("connection.salesforce.authenticationType", "invalid-type");
+        properties.setProperty("connection.salesforce.userName", "testUser");
+        properties.setProperty("connection.salesforce.password", "testPass");
+
+        buildStreamData(properties);
+    }
+
+    @Test(expectedExceptions = SynapseException.class,
+            description = "username-token without userName throws SynapseException")
+    public void testUsernameTokenMissingUserNameThrowsException() throws Exception {
+        setupMocks();
+        Properties properties = buildBaseProperties();
+        properties.setProperty("connection.salesforce.authenticationType", "username-token");
+        properties.setProperty("connection.salesforce.password", "testPass");
+
+        buildStreamData(properties);
+    }
+
+    @Test(expectedExceptions = SynapseException.class,
+            description = "username-token without password throws SynapseException")
+    public void testUsernameTokenMissingPasswordThrowsException() throws Exception {
+        setupMocks();
+        Properties properties = buildBaseProperties();
+        properties.setProperty("connection.salesforce.authenticationType", "username-token");
+        properties.setProperty("connection.salesforce.userName", "testUser");
+
+        buildStreamData(properties);
+    }
+
+    @Test(expectedExceptions = SynapseException.class,
+            description = "oauth without clientId throws SynapseException")
+    public void testOauthMissingClientIdThrowsException() throws Exception {
+        setupMocks();
+        Properties properties = buildBaseProperties();
+        properties.setProperty("connection.salesforce.authenticationType", "oauth");
+        properties.setProperty("connection.salesforce.clientSecret", "testClientSecret");
+
+        buildStreamData(properties);
+    }
+
+    @Test(expectedExceptions = SynapseException.class,
+            description = "oauth without clientSecret throws SynapseException")
+    public void testOauthMissingClientSecretThrowsException() throws Exception {
+        setupMocks();
+        Properties properties = buildBaseProperties();
+        properties.setProperty("connection.salesforce.authenticationType", "oauth");
+        properties.setProperty("connection.salesforce.clientId", "testClientId");
+
+        buildStreamData(properties);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void setupMocks() throws Exception {
+        System.setProperty("carbon.home", ".");
+        PowerMockito.mockStatic(PrivilegedCarbonContext.class);
+        PowerMockito.mockStatic(CarbonContext.class);
+        AbstractRegistry registry = Mockito.mock(AbstractRegistry.class);
+        SynapseConfiguration config = Mockito.mock(SynapseConfiguration.class);
+        Mockito.when(config.getRegistry()).thenReturn(registry);
+        this.synapseEnvironment = Mockito.mock(SynapseEnvironment.class);
+        Mockito.when(synapseEnvironment.getSynapseConfiguration()).thenReturn(config);
+        PrivilegedCarbonContext privilegedCarbonContext = Mockito.mock(PrivilegedCarbonContext.class);
+        PowerMockito.when(PrivilegedCarbonContext.getThreadLocalCarbonContext()).thenReturn(privilegedCarbonContext);
+    }
+
+    private Properties buildBaseProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("inbound.behavior", "polling");
+        properties.setProperty("interval", "1000");
+        properties.setProperty("sequential", "true");
+        properties.setProperty("coordination", "true");
+        properties.setProperty("connection.salesforce.salesforceObject", "/topic/TestTopic");
+        properties.setProperty("connection.salesforce.packageVersion", "37.0");
+        properties.setProperty("connection.salesforce.connectionTimeout", "10000");
+        properties.setProperty("connection.salesforce.waitTime", "5000");
+        properties.setProperty("connection.salesforce.soapApiVersion", "22.0");
+        return properties;
+    }
+
+    private SalesforceStreamData buildStreamData(Properties properties) {
+        return new SalesforceStreamData(properties, "TestEP", synapseEnvironment, 100, "testSeq", "faultSeq", true, true);
+    }
+
+    public void loadPropertiesFromFile(Properties prop) {
         Properties properties = new Properties();
         try {
             InputStream input = getClass().getClassLoader().getResourceAsStream("Property.properties");
@@ -140,6 +320,9 @@ public class SalesforceStreamDataTest extends PowerMockTestCase {
             prop.setProperty("connection.salesforce.salesforceObject", properties.getProperty("salesforceObject"));
             prop.setProperty("connection.salesforce.loginEndpoint", properties.getProperty("loginEndpoint"));
             prop.setProperty("connection.salesforce.password", properties.getProperty("password"));
+            prop.setProperty("connection.salesforce.clientId", properties.getProperty("clientId"));
+            prop.setProperty("connection.salesforce.clientSecret", properties.getProperty("clientSecret"));
+            prop.setProperty("connection.salesforce.tokenEndpoint", properties.getProperty("tokenEndpoint"));
             input.close();
         } catch (Exception e) {
             LOG.error("Properties reading failed  :", e);

--- a/src/test/resources/Property.properties
+++ b/src/test/resources/Property.properties
@@ -3,3 +3,6 @@ EventIDStoredFilePath=
 salesforceObject=
 loginEndpoint=
 password=
+clientId=
+clientSecret=
+tokenEndpoint=


### PR DESCRIPTION
## Purpose
Adds OAuth2 Client Credentials as an alternative authentication method alongside the existing SOAP username/password login. Introduces the following new configuration parameters:

- connection.salesforce.authenticationType:  username-token (default, existing behavior) or oauth
- connection.salesforce.clientId: OAuth2 consumer key
- connection.salesforce.clientSecret: OAuth2 consumer secret
- connection.salesforce.tokenEndpoint: OAuth2 token endpoint (defaults to https://login.salesforce.com/services/oauth2/token)

Fixes: https://github.com/wso2/product-integrator-mi/issues/4905